### PR TITLE
Feature/37 docker selenium test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ target/
 *.log
 test/unit/coverage
 test/e2e/reports
+.docker
 
 # Editor directories and files
 .idea/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
     stage('Build') {
        steps {
          withMaven {
-           sh 'mvn clean verify'
+           sh './docker-mvn.sh clean verify'
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
     stage('Build') {
        steps {
          withMaven {
-           sh 'mvn clean test'
+           sh 'mvn clean verify'
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
       }
       steps {
         withMaven {
-          sh 'mvn  -Pdocker-build resources:copy-resources@copy-dockerfile resources:copy-resources@copy-dist docker:build docker:push'
+          sh 'mvn -Pdocker-build resources:copy-resources@copy-dockerfile resources:copy-resources@copy-dist docker:build docker:push'
           build job: 'docker_restart_develop_latest'
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
     stage('Build') {
        steps {
          withMaven {
-           sh './docker-mvn.sh clean verify'
+           sh './docker-mvn.sh clean verify -Pheadless'
         }
       }
     }

--- a/doc/DEVELOPER.adoc
+++ b/doc/DEVELOPER.adoc
@@ -109,6 +109,22 @@ To lock the package versions to ensure that they are not incidentially updated b
 
 === Testing the application
 
+Testing can be performed in the following modes
+
+Testing with NPM:: cf. <<Testing with NPM>>.
+
+NOTE:
+Both of the following modes are based on this mode and effectively call `npm` but are used via Maven which enables a local installation of the desired NPM and Node versions first.
+It then uses these versions to perform the build and test of the application.
+On CI (https://dev.dukecon.org/jenkins/job/dukecon_pwa/[The DukeCon Jenkins]) the build and tests are performed via this mode.
+
+Build with Maven (directly):: cf. <<Testing with Maven (direct)>>
+
+Build with Maven (in Docker):: cf. <<Testing with Maven (Docker)>>
+
+==== Testing with NPM
+
+===== Unit testing
 To run all unit tests run
 
 ----
@@ -124,21 +140,60 @@ npm run unitloop
 NOTE: It might happen that PhantomJS terminates due to inactivity.
 In this case open up the URL in Chrome: http://localhost:9876/
 
+===== Integration testing (End-to-End testing)
+
 To run the integration tests you need a local Chrome browser installed.
 You'll also need a connection to the internet as this will start the frontend in development mode that will proxy all _/rest_ resources to _https://latest.dukecon.org/javaland/2019_.
 It will also connect to the Dukecon's Keycloak instance.
+
+[[caution:chrome-does-not-work]]
+[CAUTION]
+.Chrome does not work for automatic browser testing
+====
+This does not work with current versions of Chrome (as they might be installed on your local machine as well as with current Linux distributions as used by Docker).
+Therefor end-to-end testing is recommended based on the headless mode (see <<Headless integration testing>>).
+====
+
 Use the following command to run them:
 
 ----
 npm run e2e
 ----
 
-To run the integration tests in a Chrome browser in the background (headless) use the following command.
-At the time this is written this still need a display when build on Travis CI using _xvfb-run_.
-See _.travis.yml_ for details.
+===== Headless integration testing
+
+To run the integration tests in a Firefox browser in the background (headless) use the following command.
+At the time this is written this still needs a display using _xvfb-run_.
+See link:../docker-mvn.sh[docker-mvn.sh] for details.
 
 ----
 npm run e2e_headless
+----
+
+==== Testing with Maven (direct)
+
+The Maven build is based on the Maven Frontend Plugin.
+During the build lifecycle a local installation of NPM and Node in the desired versions is performed first:
+
+[source,xml]
+----
+include::../pom.xml[tag=node-npm-versions]
+----
+
+In all subsequent build stages these versions are used
+
+`mvn test`:: can be used to perform the the build and unit test.
+`mvn verify`:: can be used to perform the build and test including the end-to-end test with a real browser (see <<caution:chrome-does-not-work>>).
+`mvn verify -Pheadless`:: Used to run with Firefox instead of Chrome (cf. <<Headless integration testing>>)
+`mvn clean`:: may be used as usual to clean up the local build.
+`mvn clean -Pveryclean`:: also cleans up the NPM and Node installation.
+
+==== Testing with Maven (Docker)
+
+If you want to run the build as it is done on our CI-Server (Jenkins), please run `./docker-mvn.sh` with the deired Maven goals, e.g.,
+
+----
+./docker-mvn.sh clean verify -Pheadless
 ----
 
 == Offline Functionality

--- a/doc/DEVELOPER.adoc
+++ b/doc/DEVELOPER.adoc
@@ -111,17 +111,18 @@ To lock the package versions to ensure that they are not incidentially updated b
 
 Testing can be performed in the following modes
 
-Testing with NPM:: cf. <<Testing with NPM>>.
+Testing with NPM:: cf. <<sec:testing-with-npm>>.
 
 NOTE:
 Both of the following modes are based on this mode and effectively call `npm` but are used via Maven which enables a local installation of the desired NPM and Node versions first.
 It then uses these versions to perform the build and test of the application.
 On CI (https://dev.dukecon.org/jenkins/job/dukecon_pwa/[The DukeCon Jenkins]) the build and tests are performed via this mode.
 
-Build with Maven (directly):: cf. <<Testing with Maven (direct)>>
+Build with Maven (directly):: cf. <<sec:testing-with-maven-direct>>
 
-Build with Maven (in Docker):: cf. <<Testing with Maven (Docker)>>
+Build with Maven (in Docker):: cf. <<sec:testing-with-maven-docker>>
 
+[[sec:testing-with-npm]]
 ==== Testing with NPM
 
 ===== Unit testing
@@ -151,7 +152,7 @@ It will also connect to the Dukecon's Keycloak instance.
 .Chrome does not work for automatic browser testing
 ====
 This does not work with current versions of Chrome (as they might be installed on your local machine as well as with current Linux distributions as used by Docker).
-Therefor end-to-end testing is recommended based on the headless mode (see <<Headless integration testing>>).
+Therefor end-to-end testing is recommended based on the headless mode (see <<sec:headless-integration-testing>>).
 ====
 
 Use the following command to run them:
@@ -160,6 +161,7 @@ Use the following command to run them:
 npm run e2e
 ----
 
+[[sec:headless-integration-testing]]
 ===== Headless integration testing
 
 To run the integration tests in a Firefox browser in the background (headless) use the following command.
@@ -170,6 +172,7 @@ See link:../docker-mvn.sh[docker-mvn.sh] for details.
 npm run e2e_headless
 ----
 
+[[sec:testing-with-maven-direct]]
 ==== Testing with Maven (direct)
 
 The Maven build is based on the Maven Frontend Plugin.
@@ -184,10 +187,11 @@ In all subsequent build stages these versions are used
 
 `mvn test`:: can be used to perform the the build and unit test.
 `mvn verify`:: can be used to perform the build and test including the end-to-end test with a real browser (see <<caution:chrome-does-not-work>>).
-`mvn verify -Pheadless`:: Used to run with Firefox instead of Chrome (cf. <<Headless integration testing>>)
+`mvn verify -Pheadless`:: Used to run with Firefox instead of Chrome (cf. <<sec:headless-integration-testing>>)
 `mvn clean`:: may be used as usual to clean up the local build.
 `mvn clean -Pveryclean`:: also cleans up the NPM and Node installation.
 
+[[sec:testing-with-maven-docker]]
 ==== Testing with Maven (Docker)
 
 If you want to run the build as it is done on our CI-Server (Jenkins), please run `./docker-mvn.sh` with the deired Maven goals, e.g.,

--- a/docker-mvn.sh
+++ b/docker-mvn.sh
@@ -4,6 +4,7 @@ tty_option=""
 tty -s && tty_option="-t"
 
 : ${USER_HOME:="/root"}
+: ${MAVEN_CMD:="mvn -Pheadless"}
 
 exec docker run -i ${tty_option} --rm \
   -v "$HOME/.m2:$USER_HOME/.m2" \
@@ -11,5 +12,5 @@ exec docker run -i ${tty_option} --rm \
   -v "$PWD":/usr/src \
   -w /usr/src \
   -e MAVEN_CONFIG=$USER_HOME/.m2 \
-  dukecon/dukecon-maven:latest \
-  /bin/sh -c "/usr/bin/xvfb-run -s \"-screen 0 2560x1440x8\" -a -e xvfb.err -- mvn $*"
+  dukecon/dukecon-maven:3.6.3-adoptopenjdk-14 \
+  /bin/sh -c "/usr/bin/xvfb-run -s \"-screen 0 2560x1440x8\" -a -e xvfb.err -- ${MAVEN_CMD} ${*}"

--- a/docker-mvn.sh
+++ b/docker-mvn.sh
@@ -7,7 +7,7 @@ tty -s && tty_option="-t"
 
 : ${USER:="dukecon"}
 : ${USER_HOME:="/home"}
-: ${MAVEN_CMD:="mvn -Pheadless"}
+: ${MAVEN_CMD:="mvn"}
 : ${MAVEN_OPTS:=""}
 
 # Setting of Java user.home property is necessary when using '-u' on Docker call since the Docker container

--- a/docker-mvn.sh
+++ b/docker-mvn.sh
@@ -1,18 +1,24 @@
 #!/bin/bash
 
+set -eu
+
 tty_option=""
 tty -s && tty_option="-t"
 
-: ${USER_HOME:="/root"}
+: ${USER_HOME:="/tmp"}
 : ${MAVEN_CMD:="mvn -Pheadless"}
+
+mkdir -p $PWD/.docker/{tmp,node,node_modules,npm}
 
 exec docker run -i ${tty_option} --rm \
   -v "$HOME/.m2:$USER_HOME/.m2" \
-  -v "$PWD/.npm:$USER_HOME/.npm" \
+  -v "$PWD/.docker/npm:$USER_HOME/.npm" \
   -v "$PWD":/usr/src \
-  -v "$PWD/.docker/node":/usr/src/node \
-  -v "$PWD/.docker/node_modules":/usr/src/node_modules \
+  -v "$PWD/.docker/node:/usr/src/node" \
+  -v "$PWD/.docker/node_modules:/usr/src/node_modules" \
+  -u $(id -u) \
   -w /usr/src \
+  -e HOME=$USER_HOME \
   -e MAVEN_CONFIG=$USER_HOME/.m2 \
   dukecon/dukecon-maven:3.6.3-adoptopenjdk-14 \
-  /bin/sh -c "/usr/bin/xvfb-run -s \"-screen 0 2560x1440x8\" -a -e xvfb.err -- ${MAVEN_CMD} ${*}"
+  /bin/sh -c "/usr/bin/xvfb-run -s \"-screen 0 2560x1440x8\" -a -e /tmp/xvfb.err -- ${MAVEN_CMD} ${*}"

--- a/docker-mvn.sh
+++ b/docker-mvn.sh
@@ -5,20 +5,33 @@ set -eu
 tty_option=""
 tty -s && tty_option="-t"
 
-: ${USER_HOME:="/tmp"}
+: ${USER:="dukecon"}
+: ${USER_HOME:="/home"}
 : ${MAVEN_CMD:="mvn -Pheadless"}
+: ${MAVEN_OPTS:=""}
 
-mkdir -p $PWD/.docker/{tmp,node,node_modules,npm}
+mkdir -p ${PWD}/.docker/{home,node,node_modules,npm}
 
 exec docker run -i ${tty_option} --rm \
-  -v "$HOME/.m2:$USER_HOME/.m2" \
-  -v "$PWD/.docker/npm:$USER_HOME/.npm" \
-  -v "$PWD":/usr/src \
-  -v "$PWD/.docker/node:/usr/src/node" \
-  -v "$PWD/.docker/node_modules:/usr/src/node_modules" \
-  -u $(id -u) \
+  -v "${PWD}:/usr/src" \
   -w /usr/src \
-  -e HOME=$USER_HOME \
-  -e MAVEN_CONFIG=$USER_HOME/.m2 \
+  \
+  -u "$(id -u)" \
+  -e "MAVEN_OPTS=-Duser.home=${USER_HOME} ${MAVEN_OPTS}" \
+  \
+  -v "${HOME}/.m2:${USER_HOME}/.m2" \
+  -e "HOME=${USER_HOME}" \
+  -e "USER_HOME_DIR=${USER_HOME}" \
+  -e "MAVEN_CONFIG=${USER_HOME}/.m2" \
+  -e "USER=${USER}" \
+  \
+  -v "${PWD}/.docker/home:${USER_HOME}" \
+  -v "${PWD}/.docker/npm:${USER_HOME}/.npm" \
+  -v "${PWD}/.docker/node:/usr/src/node" \
+  -v "${PWD}/.docker/node_modules:/usr/src/node_modules" \
+  \
   dukecon/dukecon-maven:3.6.3-adoptopenjdk-14 \
   /bin/sh -c "/usr/bin/xvfb-run -s \"-screen 0 2560x1440x8\" -a -e /tmp/xvfb.err -- ${MAVEN_CMD} ${*}"
+
+  maven:3.6.3-adoptopenjdk-14 /bin/sh -c "${MAVEN_CMD} ${*}"
+

--- a/docker-mvn.sh
+++ b/docker-mvn.sh
@@ -10,11 +10,11 @@ tty -s && tty_option="-t"
 : ${MAVEN_CMD:="mvn -Pheadless"}
 : ${MAVEN_OPTS:=""}
 
-mkdir -p ${PWD}/.docker/{home,node,node_modules,npm}
 # Setting of Java user.home property is necessary when using '-u' on Docker call since the Docker container
 # cannot determine a valid Home for this use. Then Maven uses '?' as the user home, settings.xml etc. cannot be
 # found and this results in subsequent problems.
 
+mkdir -p ${PWD}/.docker/{home,logs,node,node_modules,npm,tmp}
 
 exec docker run -i ${tty_option} --rm \
   -v "${PWD}:/usr/src" \
@@ -30,12 +30,14 @@ exec docker run -i ${tty_option} --rm \
   -e "USER=${USER}" \
   \
   -v "${PWD}/.docker/home:${USER_HOME}" \
+  -v "${PWD}/.docker/logs:/usr/src/logs" \
   -v "${PWD}/.docker/npm:${USER_HOME}/.npm" \
   -v "${PWD}/.docker/node:/usr/src/node" \
   -v "${PWD}/.docker/node_modules:/usr/src/node_modules" \
+  -v "${PWD}/.docker/tmp:/tmp" \
   \
   dukecon/dukecon-maven:3.6.3-adoptopenjdk-14 \
-  /bin/sh -c "/usr/bin/xvfb-run -s \"-screen 0 2560x1440x8\" -a -e /tmp/xvfb.err -- ${MAVEN_CMD} ${*}"
+  /bin/sh -c "/usr/bin/xvfb-run -s \"-screen 0 2560x1440x8\" -a -e logs/xvfb.err -- ${MAVEN_CMD} ${*:-}"
 
   maven:3.6.3-adoptopenjdk-14 /bin/sh -c "${MAVEN_CMD} ${*}"
 

--- a/docker-mvn.sh
+++ b/docker-mvn.sh
@@ -11,6 +11,10 @@ tty -s && tty_option="-t"
 : ${MAVEN_OPTS:=""}
 
 mkdir -p ${PWD}/.docker/{home,node,node_modules,npm}
+# Setting of Java user.home property is necessary when using '-u' on Docker call since the Docker container
+# cannot determine a valid Home for this use. Then Maven uses '?' as the user home, settings.xml etc. cannot be
+# found and this results in subsequent problems.
+
 
 exec docker run -i ${tty_option} --rm \
   -v "${PWD}:/usr/src" \

--- a/docker-mvn.sh
+++ b/docker-mvn.sh
@@ -10,6 +10,8 @@ exec docker run -i ${tty_option} --rm \
   -v "$HOME/.m2:$USER_HOME/.m2" \
   -v "$PWD/.npm:$USER_HOME/.npm" \
   -v "$PWD":/usr/src \
+  -v "$PWD/.docker/node":/usr/src/node \
+  -v "$PWD/.docker/node_modules":/usr/src/node_modules \
   -w /usr/src \
   -e MAVEN_CONFIG=$USER_HOME/.m2 \
   dukecon/dukecon-maven:3.6.3-adoptopenjdk-14 \

--- a/package-lock.json
+++ b/package-lock.json
@@ -267,6 +267,12 @@
       "dev": true,
       "optional": true
     },
+    "adm-zip": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
+      "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==",
+      "dev": true
+    },
     "after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
@@ -4843,6 +4849,15 @@
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.2"
+      }
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -5134,7 +5149,6 @@
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -6416,6 +6430,15 @@
         "klaw": "^1.0.0"
       }
     },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.6.0"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -6469,8 +6492,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -6485,7 +6508,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -6552,7 +6575,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.3.5"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -6567,14 +6590,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.3"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -6583,12 +6606,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -6612,7 +6635,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -6621,8 +6644,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -6643,7 +6666,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -6658,7 +6681,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -6673,8 +6696,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.3"
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -6683,7 +6706,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.3.5"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -6718,16 +6741,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.4",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.2.0",
-            "npmlog": "4.1.2",
-            "rc": "1.2.8",
-            "rimraf": "2.6.3",
-            "semver": "5.6.0",
-            "tar": "4.4.8"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -6736,8 +6759,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -6752,8 +6775,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.5"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -6762,10 +6785,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.5",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -6786,7 +6809,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -6807,8 +6830,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -6829,10 +6852,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.6.0",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -6849,13 +6872,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -6864,7 +6887,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.3"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
@@ -6909,9 +6932,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -6920,7 +6943,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -6929,7 +6952,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -6944,13 +6967,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "1.1.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.3.5",
-            "minizlib": "1.2.1",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.3"
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -6965,7 +6988,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
@@ -7029,6 +7052,46 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "geckodriver": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-1.19.1.tgz",
+      "integrity": "sha512-xWL/+eEhQ6+t98rc1c+xVM3hshDJibXtZf9WJA3sshxq4k5L1PBwfmswyBmmlKUfBr4xuC256gLVC2RxFhiCsQ==",
+      "dev": true,
+      "requires": {
+        "adm-zip": "0.4.11",
+        "bluebird": "3.4.6",
+        "got": "5.6.0",
+        "https-proxy-agent": "3.0.0",
+        "tar": "4.4.2"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "dev": true,
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
+        "bluebird": {
+          "version": "3.4.6",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
+          "integrity": "sha1-AdqNgh2HgT0ViWfnQ9X+bGLPjA8=",
+          "dev": true
+        },
+        "https-proxy-agent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.0.tgz",
+          "integrity": "sha512-y4jAxNEihqvBI5F3SaO2rtsjIOnnNA8sEbuiP+UhJZJHeM2NRm6c09ax2tgqme+SgUUvjao2fJXF4h3D6Cb2HQ==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
+          }
+        }
+      }
     },
     "generate-function": {
       "version": "2.3.1",
@@ -7196,6 +7259,44 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "got": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-5.6.0.tgz",
+      "integrity": "sha1-ux1+4WO3gIK7yOuDbz85UATqb78=",
+      "dev": true,
+      "requires": {
+        "create-error-class": "^3.0.1",
+        "duplexer2": "^0.1.4",
+        "is-plain-obj": "^1.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "node-status-codes": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "parse-json": "^2.1.0",
+        "pinkie-promise": "^2.0.0",
+        "read-all-stream": "^3.0.0",
+        "readable-stream": "^2.0.5",
+        "timed-out": "^2.0.0",
+        "unzip-response": "^1.0.0",
+        "url-parse-lax": "^1.0.0"
+      },
+      "dependencies": {
+        "timed-out": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
+          "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo=",
+          "dev": true
+        },
+        "unzip-response": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+          "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
           "dev": true
         }
       }
@@ -10156,6 +10257,33 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.9.0"
+      }
+    },
     "mississippi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
@@ -10775,6 +10903,12 @@
       "requires": {
         "semver": "^5.3.0"
       }
+    },
+    "node-status-codes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
+      "dev": true
     },
     "nodemailer": {
       "version": "2.7.2",
@@ -14120,6 +14254,16 @@
         }
       }
     },
+    "read-all-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      }
+    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -16088,6 +16232,29 @@
       "integrity": "sha1-ry2LvJsE907hevK02QSPgHrNGKg=",
       "dev": true
     },
+    "tar": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.2.tgz",
+      "integrity": "sha512-BfkE9CciGGgDsATqkikUHrQrraBCO+ke/1f6SFAEMnxyyfN9lxC+nW1NFWMpqH865DhHIy9vQi682gk1X7friw==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.0.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.2.4",
+        "minizlib": "^1.1.0",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
+      }
+    },
     "tcp-port-used": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.1.tgz",
@@ -16766,6 +16933,15 @@
       "requires": {
         "querystringify": "^2.0.0",
         "requires-port": "^1.0.0"
+      }
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^1.0.1"
       }
     },
     "use": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "unit": "cross-env BABEL_ENV=test karma start test/unit/karma.conf.js --single-run",
     "unitloop": "cross-env BABEL_ENV=test karma start test/unit/karma.conf.js --auto-run",
     "e2e": "node test/e2e/runner.js --env chrome",
-    "e2e_headless": "node test/e2e/runner.js --env chromeheadless",
+    "e2e_headless": "node test/e2e/runner.js --env firefox",
     "test": "npm run unit && npm run e2e",
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"
   },
@@ -65,6 +65,7 @@
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^1.1.11",
     "friendly-errors-webpack-plugin": "^1.7.0",
+    "geckodriver": "^1.19.1",
     "git-revision-webpack-plugin": "^2.5.1",
     "har-validator": "^5.0.3",
     "html-webpack-plugin": "^2.30.1",

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
       </build>
     </profile>
     <profile>
-      <id>chromeheadless</id>
+      <id>headless</id>
       <build>
         <plugins>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,11 @@
     <maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
     <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
     <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
+
+    <!-- tag::node-npm-versions[] -->
     <node.version>v10.16.0</node.version>
     <npm.version>6.10.2</npm.version>
+    <!-- end::node-npm-versions[] -->
 
     <!-- IntelliJ generates new version properties here - move them above every now and then -->
   </properties>
@@ -178,6 +181,7 @@
                     <include>npm-debug.log</include>
                     <include>node/</include>
                     <include>node_modules/</include>
+                    <include>.docker</include>
                   </includes>
                   <followSymlinks>false</followSymlinks>
                 </fileset>

--- a/test/e2e/nightwatch.conf.js
+++ b/test/e2e/nightwatch.conf.js
@@ -13,7 +13,8 @@ module.exports = {
     host: '127.0.0.1',
     port: 4444,
     cli_args: {
-      'webdriver.chrome.driver': require('chromedriver').path
+      'webdriver.chrome.driver': require('chromedriver').path,
+      'webdriver.gecko.driver': require('geckodriver').path
     }
   },
 

--- a/test/e2e/nightwatch.conf.js
+++ b/test/e2e/nightwatch.conf.js
@@ -34,7 +34,7 @@ module.exports = {
         acceptSslCerts: true,
         chromeOptions: {
           args: [
-            '--disable-gpu --no-sandbox --window-size=1920,1080 --verbose'
+            'disable-gpu', 'no-sandbox', 'window-size=1920,1080', 'verbose'
           ]
         }
       }


### PR DESCRIPTION
With these changes we can
- Use End-To-End tests again (even if Firefox must be used instead of Chrome, see below)
- Use Docker based builds (it becomes more and more difficult to maintain a Jenkins with all build tools). 
  So we should try to separate these concerns: Use Docker for the Maven/NPM build and Jenkins for everything else.

Chrome executions always failed in Selenium tests (e2e tests), due to version constraints with current releases of Chrome. It probably needs a different setup or different/current libraries if working at all for Selenium based tests. Developer documentation now describes the two flavours to run e2e tests. The test suite with Chrome can still be executed with `mvn verify` (default). For builds with Docker (used on Jenkins) we switched to Firefox as browser. Tests with Firefox can be executed with `mvn verify -Pheadless` (or `./docker-mvn.sh verify -Pheadless`).

We probably should discuss the issue/solution again @ahus1 @steffchep @sippsack?